### PR TITLE
Ant1b #3 add readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+B2NOTE
+======
+
+A [EUDAT](https://www.eudat.eu) service for creating, storing and managing annotations about online resources.
+
+Annotations are comments and/or indications providing extra information about a resource such as a data-file.
+
+The B2Note prototype service allows terms defined in controlled vocabularies, ontologies and thesauri to be used in annotations.
+
+<b>[Click here for B2Note demo.](https://b2note.bsc.es/devel)</b>
+
+The data model used in B2Note is based on the [W3C web annotation data model](http://www.w3.org/TR/annotation-model/).
+
+##Contributors
+
+ Name  |  Affiliation | Contact
+-------|-------|-------
+Dr. Yann Le Franc   | e-Science Data Factory | ylefranc@esciencefactory.com
+Dr. Antoine Brémaud | e-Science Data Factory | [abremaud@esciencefactory.com](mailto:abremaud@esciencefactory.com)
+Mr. Pablo Ródenas Barquero | Barcelona Supercomputing Center | pablo.rodenas@bsc.es
+
+
+##Instructions for contributing
+
+Please follow along guidelines outlined at:
+
+[HOW TO GITHUB [...] by Rich Jones.](https://gun.io/blog/how-to-github-fork-branch-and-pull-request/)
+
+With the addition that the **name of the worked-on fork-branch** eventually submitted for a pull request should be formatted as follows:
+
+> _contributor_short_id_ (optional) **_** _#issue_reference_number_ **_** _Code_change_description_ (omitting spaces)
+
+In short:
+1. Log an **issue** on source repository: [EUDAT-B2NOTE/b2note](https://github.com/EUDAT-B2NOTE/b2note/issues/new).
+    1. Describe contribution objectives.
+2. **Fork** branch of interest (or update fork if previously forked).
+    1. Branch out from fork base using naming convention detailed above.
+3. **Commit** changes to branched out code.
+4. **Submit** reasonably documented pull request to branch of interest.
+    1. May require preemptive alignment to target branch latest code.
+
+
+##License
+
+Copyright (c) 2014, EUDAT project funded from the European Union under grant agreement n.283304.
+
+Copyright (c) 2015, EUDAT2020 project funded from the European Union under grant agreement n.654065.
+
+All rights reserved.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ With the addition that the **name of the worked-on fork-branch** eventually subm
 > _contributor_short_id_ (optional) **_** _#issue_reference_number_ **_** _Code_change_description_ (omitting spaces)
 
 In short:
+
 1. Log an **issue** on source repository: [EUDAT-B2NOTE/b2note](https://github.com/EUDAT-B2NOTE/b2note/issues/new).
     1. Describe contribution objectives.
 2. **Fork** branch of interest (or update fork if previously forked).


### PR DESCRIPTION
README.md displayed on homepage for providing visitor with essential
information about project.

Specifying service objectives, contributors, affiliations, contact
details, contributing instructions, license info.

Preliminary version missing license information and instructions for
local install.