### PR TITLE
Ant1b #5 typeahead fixed number of results

### DIFF
--- a/static/js/ontology-typeahead.js
+++ b/static/js/ontology-typeahead.js
@@ -52,7 +52,7 @@ $(document).ready( function() {
     $('#id_q').typeahead({
             hint: true,
             highlight: true,
-            minLength: 3,
+            minLength: 1,
         },
         {
             name: 'engine',

--- a/static/js/ontology-typeahead.js
+++ b/static/js/ontology-typeahead.js
@@ -14,7 +14,8 @@ $(document).ready( function() {
         },
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         remote: {
-            url: window.location.protocol + '//b2note.bsc.es/solr/b2note_index/select?q=%QUERY&wt=json&indent=true&rows=10000',
+            // What may be a relevant size of class subset for the user to select from VS. transaction size x user population?
+            url: window.location.protocol + '//b2note.bsc.es/solr/b2note_index/select?q=%QUERY&wt=json&indent=true&rows=1000',
             wildcard: '%QUERY',
             filter: function (data) {
                 return $.map(data.response.docs, function (suggestionSet) {
@@ -51,7 +52,7 @@ $(document).ready( function() {
     $('#id_q').typeahead({
             hint: true,
             highlight: true,
-            minLength: 1,
+            minLength: 3,
         },
         {
             name: 'engine',
@@ -59,7 +60,8 @@ $(document).ready( function() {
 
             source: engine.ttAdapter(),
 
-            limit: 10000,
+            // Fix from: https://github.com/twitter/typeahead.js/issues/1232
+            limit: Infinity,
 
             templates: {
                 empty: [


### PR DESCRIPTION
Pre: fixed limit of 10000 on both Solr and Typeahead resulted in no results displayed at times on typing single character in, despite 10000 matches returned by Solr, and corresponding transactions **about 10 Mb** which may not scale up very well with the number of users.
Fix: Solr **max to 1000** (may be revised later), Typeahead limit fixed to Infinity presumed to handle the stated max, hence an admitedly possibly truncated (to 1000 results) entry list displayed from the first character typed-in.
Now: Entry list does not exceed 1000 items, entry list displayed upon one character entered, corresponding transactions expected more sustainable.