### PR TITLE
Handle via API: external calls for creating annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,8 @@ db.*
 # local scripts
 *.sh
 
+# local copies
+*.bk
+
 # VI temp files
 .*.swp

--- a/b2note_api/api.wsgi
+++ b/b2note_api/api.wsgi
@@ -1,5 +1,6 @@
 from b2note_api import app as application
+import os
 
-activate_this = '/bsc/public/sw/bin/activate_this.py'
+activate_this = os.environ['B2NOTE_PREFIX_SW_PATH'] + '/bin/activate_this.py'
 execfile(activate_this, dict(__file__=activate_this))
 

--- a/b2note_api/b2note_api.py
+++ b/b2note_api/b2note_api.py
@@ -1,7 +1,20 @@
 from eve import Eve
+from flask import request
 from settings import mongo_settings
+import json, requests
 
 app = Eve(settings=mongo_settings)
+
+
+@app.route('/create_annotation', methods=['POST'])
+def post_to_django():
+    pid = request.values.get('pid_tofeed')
+    subject = request.values.get('subject_tofeed')
+    url='https://b2note.bsc.es/interface_main'
+    data = {"pid_tofeed": str(pid), "subject_tofeed": str(subject) }
+    headers = {'Content-Type':'application/json'}
+    r = requests.post(url, data=data)
+    return str(r.text)
 
 if __name__ == '__main__':
     app.run()

--- a/b2note_api/settings.py
+++ b/b2note_api/settings.py
@@ -6,11 +6,18 @@ mongo_settings = {
         'MONGO_DBNAME': os.environ['MONGODB_NAME'],
         'MONGO_USERNAME': os.environ['MONGODB_USR'],
         'MONGO_PASSWORD': os.environ['MONGODB_PWD'],
-        'DOMAIN': {'annotations': {'datasource' : { 'source': 'b2note_app_annotation' }}},
+        'DOMAIN': {
+            'annotations': {
+                'datasource' : {
+                    'source': 'b2note_app_annotation'
+                    },
+                #'url' : 'annotations/<regex("[a-f0-9]{24}"):annotation_id>/files',
+                }
+            },
         'RESOURCE_METHODS' : ['GET'],
         'ITEM_METHODS' : ['GET'],
         'ALLOW_UNKNOWN' : True, # http://stackoverflow.com/questions/34666941/python-eve-get-response-does-not-contain-contents-of-resource-unless-i-specify
-#        'DEBUG' : True,
-#        'INFO'  : True
+        'DEBUG' : True,
+        'INFO'  : True,
 }
 

--- a/b2note_app/views.py
+++ b/b2note_app/views.py
@@ -255,16 +255,10 @@ def create_annotation(request):
         output:
             object: HttpResponse with the annotations.
     """
-    #import logging
-    #LOG_FILENAME = '/home/prodenas/b2note.log'
-    #logging.basicConfig(filename=LOG_FILENAME,level=logging.DEBUG)
-
-    #logging.debug('Create annotation' + request.POST.get('free_text'))
     if request.POST.get('ontology_json'):
         CreateSemanticTag( request.POST.get('subject_tofeed'), request.POST.get('ontology_json') )
     
     if request.POST.get('free_text'):
-        #logging.debug('Inside!')
         CreateFreeText( request.POST.get('subject_tofeed'), request.POST.get('free_text') )
 
     subject_tofeed = ""

--- a/templates/b2note_app/hostpage.html
+++ b/templates/b2note_app/hostpage.html
@@ -113,7 +113,8 @@
 
                 {% for file_info in buttons_info %}
 
-                    <form action="interface_main" method="post" target="b2note_iframe">
+                <!-- For the production version the url will be pointing to https://b2note.bsc.es/api/create_annotation -->
+                <form action="https://b2note-dev.bsc.es/api/create_annotation" method="post" target="b2note_iframe">
 
                     {% csrf_token %}
 


### PR DESCRIPTION
External calls get addressed to the Python Eve API which may then relay necessary information to the Django view for display in the interface and the user to be able to trigger the creating of an annotation based on this provided information via the web interface.