### PR TITLE
Retrieve annotations function for a given target id is created in the API

### DIFF
--- a/b2note_api/b2note_api.py
+++ b/b2note_api/b2note_api.py
@@ -10,12 +10,21 @@ app = Eve(settings=mongo_settings)
 def post_to_django():
     pid = request.values.get('pid_tofeed')
     subject = request.values.get('subject_tofeed')
-    # For the production version the url will be pointing to https://b2note.bsc.es/api/create_annotation
+    # For the production version the url will be pointing to https://b2note.bsc.es/create_annotation
     url='https://b2note-dev.bsc.es/interface_main'
     data = {"pid_tofeed": str(pid), "subject_tofeed": str(subject) }
     headers = {'Content-Type':'application/json'}
-    r = requests.post(url, data=data)
+    r = requests.post(url, data=data, verify=False)
     return str(r.text)
+
+@app.route('/retrieve_annotations', methods=['GET'])
+def get_from_django():
+    target_id = request.values.get('target_id')
+    # For the production version the url will be pointing to https://b2note.bsc.es/retrieve_annotations
+    url = 'https://b2note-dev.bsc.es/retrieve_annotations'
+    data = {"target_id" : str(target_id)}
+    r = requests.get(url, params=data)
+    return str(r.text)  
 
 if __name__ == '__main__':
     app.run()

--- a/b2note_app/mongo_support_functions.py
+++ b/b2note_app/mongo_support_functions.py
@@ -5,6 +5,28 @@ from .models import *
 
 import os, datetime, json
 
+def  RetrieveAnnotations( subject_url ):
+    """
+      Function: RetrieveAnnotations
+      ----------------------------
+        Retrieves all annotations for a given file.
+        
+        params:
+            subject_url (str): ID of the file.
+        
+        returns:
+            dic: Dictionary with the values of the annotations.
+    """
+    try:        
+        annotations = Annotation.objects.raw_query({'target.jsonld_id': subject_url})
+    
+    except Annotation.DoesNotExist:
+        annotations = []
+
+    annotations = sorted(annotations, key=lambda Annotation: Annotation.created, reverse=True)
+    
+    return annotations
+
 
 def DeleteFromPOSTinfo( db_id ):
     """

--- a/b2note_app/views.py
+++ b/b2note_app/views.py
@@ -329,3 +329,24 @@ def interface_main(request):
 @csrf_exempt
 def search_annotations(request):
     return HttpResponse("Search annotations functionality is coming.")
+
+@csrf_exempt
+def retrieve_annotations(request):
+    """
+      Function: retrieve_annotations
+      ----------------------------
+        Retrieves a jsonld with annotations matching with the file in the request
+        
+        input:
+            request (object): context of the petition.
+        
+        output:
+            object: jsonld
+    """
+    target_id = ""
+    if request.GET.get('target_id') != None:
+        target_id = request.GET.get('target_id')
+    
+    annotations = RetrieveAnnotations(target_id)
+    
+    return HttpResponse(annotations)

--- a/b2note_devel/urls.py
+++ b/b2note_devel/urls.py
@@ -17,4 +17,5 @@ urlpatterns = patterns('',
     url(r'^publish', 'b2note_app.views.publish_annotations'),
     url(r'^settings', 'b2note_app.views.settings'),
     url(r'^search', 'b2note_app.views.search_annotations'),
+    url(r'^retrieve_annotations', 'b2note_app.views.retrieve_annotations'),
 )

--- a/static/js/ontology-typeahead.js
+++ b/static/js/ontology-typeahead.js
@@ -87,7 +87,7 @@ $(document).ready( function() {
 	      * Code source: https://github.com/mgalante/jquery.redirect
 	      *
               */
-            $.redirect('create_annotation',
+            $.redirect('../create_annotation',
 	    	    {
 		    	ontology_json: JSON.stringify(data.json_document),
 		    	subject_tofeed: subject,

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -69,7 +69,7 @@ function get_free_text() {
     if (elem) {
         pid = elem.getElementsByTagName("a")[1].innerHTML;
     }
-    $.redirect('create_annotation',
+    $.redirect('../create_annotation',
                {
                free_text: text,
                subject_tofeed: subject,

--- a/templates/b2note_app/hostpage.html
+++ b/templates/b2note_app/hostpage.html
@@ -114,7 +114,7 @@
                 {% for file_info in buttons_info %}
 
                 <!-- For the production version the url will be pointing to https://b2note.bsc.es/api/create_annotation -->
-                <form action="https://b2note-dev.bsc.es/api/create_annotation" method="post" target="b2note_iframe">
+                <form action="/api/create_annotation" method="post" target="b2note_iframe">
 
                     {% csrf_token %}
 

--- a/templates/b2note_app/interface_main.html
+++ b/templates/b2note_app/interface_main.html
@@ -60,7 +60,7 @@
 
                             <li>
 
-                                <form action="export_annotations" method="post">
+                                <form action="../export_annotations" method="post">
 
                                     <input type="hidden" name="subject_tofeed" value="{{subject_tofeed}}" readonly="readonly" />
                                     <input type="hidden" name="pid_tofeed" value="{{pid_tofeed}}" readonly="readonly" />
@@ -73,7 +73,7 @@
 
                             <li>
 
-                                <form action="publish_annotations" method="post">
+                                <form action="../publish_annotations" method="post">
 
                                     <input type="hidden" name="subject_tofeed" value="{{subject_tofeed}}" readonly="readonly" />
                                     <input type="hidden" name="pid_tofeed" value="{{pid_tofeed}}" readonly="readonly" />
@@ -85,7 +85,7 @@
 
                             <li>
 
-                                <form action="settings" method="post">
+                                <form action="../settings" method="post">
 
                                     <input type="hidden" name="subject_tofeed" value="{{subject_tofeed}}" readonly="readonly" />
                                     <input type="hidden" name="pid_tofeed" value="{{pid_tofeed}}" readonly="readonly" />
@@ -198,7 +198,7 @@
 
                                                 <tr>
 
-                                                    <form action="delete_annotation" method="post">
+                                                    <form action="../delete_annotation" method="post">
 
                                                         <input type="hidden" name="db_id" value="{{annotation.id}}" readonly="readonly" />
                                                         <input type="hidden" name="subject_tofeed" value="{{subject_tofeed}}" readonly="readonly" />


### PR DESCRIPTION
Due to the fact that all redirections are done within the API namespace, they had been changed by pointing to their parent and then avoid the /api in the URL.