### PR TITLE
Tests for creating annotations have been improved by checking the DB.

### DIFF
--- a/b2note_app/mongo_support_functions.py
+++ b/b2note_app/mongo_support_functions.py
@@ -91,6 +91,8 @@ def CreateSemanticTag( subject_url, object_json ):
             annotation = Annotation.objects.get(id=my_id)
             annotation.body = [TextualBody( jsonld_id = object_uri, type = ["TextualBody"], value = object_label )]
             annotation.save()
+            print "Created semantic tag annotation"
+            return annotation.id
         else:
             print "The object does not contain URI as a key."
             return False
@@ -98,9 +100,6 @@ def CreateSemanticTag( subject_url, object_json ):
     except ValueError:
         print "Could not save to DB a semantic tag"
         return False
-
-    print "Created semantic tag annotation"
-    return True
 
 def CreateFreeText( subject_url, text ):
     """
@@ -113,7 +112,7 @@ def CreateFreeText( subject_url, text ):
             text (str): Free text introduced by the user
         
         returns:
-            bool: True if successful, False otherwise.
+            bool: id of the document created, False otherwise.
     """
     
     try:
@@ -127,6 +126,8 @@ def CreateFreeText( subject_url, text ):
             annotation = Annotation.objects.get(id=my_id)
             annotation.body = [TextualBody( type = ["TextualBody"], value = text )]
             annotation.save()
+            print "Created free text annotation"
+            return annotation.id
         else:
             print "Wrong text codification or empty text"
             return False
@@ -134,9 +135,6 @@ def CreateFreeText( subject_url, text ):
     except ValueError:
         print "Could not save to DB a free text"
         return False
-
-    print "Created free text annotation"
-    return True
 
 
 def CreateAnnotation(target):

--- a/b2note_app/tests.py
+++ b/b2note_app/tests.py
@@ -70,8 +70,17 @@ class B2noteappTest(TestCase):
         self.assertEqual(a.jsonld_id, "test")
         
     def test_create_annotation(self):
+        # DB just created with no annotations in there
+        before = Annotation.objects.filter().count()
+        self.assertEqual(before, 0)
         a = CreateAnnotation(u"test_target")
         self.assertTrue(type(a) is unicode and len(a)>0)
+        # DB with 1 annotations created
+        after = Annotation.objects.filter().count()
+        self.assertEqual(after, 1)
+        # get the ID of the created annotation
+        db_id = Annotation.objects.filter()[0].id
+        self.assertEqual(a, db_id)
         
     def test_dont_create_annotation(self):
         a = CreateAnnotation(1234)
@@ -82,8 +91,18 @@ class B2noteappTest(TestCase):
         #self.assertEqual(a, None)
         
     def test_create_semantic_tag(self):
+        # DB just created with no annotations in there
+        before = Annotation.objects.filter().count()
+        self.assertEqual(before, 0)
         a = CreateSemanticTag(u"https://b2share.eudat.eu/record/30", '{"uris":"test_uri", "labels": "test_label"}')
         self.assertTrue(a)
+        # DB with 1 annotations created
+        after = Annotation.objects.filter().count()
+        self.assertEqual(after, 1)
+        # get the ID of the created annotation
+        db_id = Annotation.objects.filter()[0].id
+        self.assertEqual(a, db_id)
+        
         
     def test_dont_create_semantic_tag(self):
         a = CreateSemanticTag(1234, '{"uris":"test_uri", "labels": "test_label"}')
@@ -92,8 +111,17 @@ class B2noteappTest(TestCase):
         self.assertTrue(not a)
         
     def test_create_free_text(self):
+        # DB just created with no annotations in there
+        before = Annotation.objects.filter().count()
+        self.assertEqual(before, 0)
         a = CreateFreeText(u"https://b2share.eudat.eu/record/30", u"testing free text")
         self.assertTrue(a)
+        # DB with 1 annotations created
+        after = Annotation.objects.filter().count()
+        self.assertEqual(after, 1)
+        # get the ID of the created annotation
+        db_id = Annotation.objects.filter()[0].id
+        self.assertEqual(a, db_id)
         
     def test_dont_create_free_text(self):
         a = CreateFreeText(u"https://b2share.eudat.eu/record/30", 1234)


### PR DESCRIPTION
The returned valued from CreateSemanticTag and CreateFreeText functions in mongo_support_functions.py has been changed from True to the id of the created document. As the id is always distinct from 0  or None, this is also a True value.