### PR TITLE
Added hidden_field element to captcha form

### DIFF
--- a/templates/captcha/hidden_field.html
+++ b/templates/captcha/hidden_field.html
@@ -1,0 +1,1 @@
+<input id="id_captcha_0" name="captcha_0" type="hidden" value={{key}} />


### PR DESCRIPTION
Native captcha template could not be located when running on server
after pip install of simple-captcha:

> Django tried loading these templates, in this order:
> 
>     Using loader django.template.loaders.filesystem.Loader:
> 
> /bsc/public/b2note_project/b2note_devel/templates/captcha/hidden_field.h
> tml (File does not exist)
>     Using loader django.template.loaders.app_directories.Loader:
> 
> /bsc/public/sw_devel/lib/python2.7/site-packages/django/contrib/auth/tem
> plates/captcha/hidden_field.html (File does not exist)