### PR TITLE
edit_annotation view fixing#01

### DIFF
--- a/b2note_app/views.py
+++ b/b2note_app/views.py
@@ -63,7 +63,19 @@ def edit_annotation(request):
 
                         error_loc.append(7)
 
-                        owner = userprofile.nickname == A.creator[0].nickname
+                        if A.creator[0].nickname and userprofile.nickname:
+
+                            error_loc.append('7b')
+
+                            if isinstance(A.creator[0].nickname, (str, unicode)) and isinstance(userprofile.nickname, (str, unicode)):
+
+                                error_loc.append('7c')
+
+                                if userprofile.nickname == A.creator[0].nickname:
+
+                                    error_loc.append('7d')
+
+                                    owner = True
 
                         error_loc.append(8)
 


### PR DESCRIPTION
Previous annotation documents did not include a creator field therefore
nickname cannot be retrieved and comparison to current logged-in user
nickname throws (was throwing) an Error. Now checking for validity of
annotation creator nickname before processing.