### PR TITLE
test_export url

### DIFF
--- a/b2note_api/jsonld_support_functions.py
+++ b/b2note_api/jsonld_support_functions.py
@@ -53,6 +53,7 @@ def retrieve_annotation_jsonld_from_api():
                 else:
                     print "retrieve_annotation_jsonld_from_api function, no jsonld data retrieved, page:" + str(pg) +"."
                     stdlogger.error("retrieve_annotation_jsonld_from_api, no jsonld data retrieved, page:" + str(pg) +".")
+
             out = annL
         else:
             print "retrieve_annotation_jsonld_from_api function, no jsonld data retrieved."

--- a/b2note_api/test_rdf.rdf
+++ b/b2note_api/test_rdf.rdf
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+   xmlns:oa="http://www.w3.org/ns/oa#"
+   xmlns:as="http://www.w3.org/ns/activitystreams#"
+   xmlns:foaf="http://xmlns.com/foaf/0.1/"
+   xmlns:dcterms="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+>
+</rdf:RDF>


### PR DESCRIPTION
Making RDF annotation per annotation takes about 5min 30s for 1000,
instead of 3min for 8800 with export_to_triplestore call constructing
the full RDF graph of the (arbitrarily expanded) annotation list…
Not pursued for evaluating triplestore rdf_sink synchronising
capabilities and graph loading process time.