### PR TITLE
AymRod_#341_fix_captcha_install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+django==1.11.8
 mongoengine==0.10.6
 pymongo==3.2.2
 pysolr==3.5.0


### PR DESCRIPTION
Add django 1.11.8 in requirements.txt to prevent other requirements from installing django 2.0, which is not compatible with python 2.7. django 1.11.8 is later deinstalled and django 1.5.11 is installed instead.
Also, move b2access endpoints to a json file.